### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Nordic",
 	"version": "1.4.0",
-	"minAppVersion": "1.5.8",
+	"minAppVersion": "1.13.0",
 	"author": "Nato",
 	"authorUrl": "https://github.com/natowb"
 }

--- a/src/editor/callout.scss
+++ b/src/editor/callout.scss
@@ -5,7 +5,7 @@
   --callout-title-background: var(--callout-color);
   --callout-border-opacity: .5;
   --callout-radius: 0;
-  border: 1px solid rgba(var(--callout-color), var(--callout-border-opacity));
+  border: 1px solid color-mix(in srgb, var(--callout-color) calc(var(--callout-border-opacity) * 100%), transparent);
 
 }
 
@@ -15,8 +15,8 @@
 }
 
 .callout-content {
-  --bold-color: rgb(var(--callout-color));
-  --list-marker-color: rgb(var(--callout-color));
+  --bold-color: var(--callout-color);
+  --list-marker-color: var(--callout-color);
 }
 
 
@@ -25,11 +25,11 @@
 .theme-dark:not(.nordic-colored-headers),
 .theme-light:not(.nordic-colored-headers) {
   .callout {
-    --h1-color: rgb(var(--callout-color));
-    --h2-color: rgb(var(--callout-color));
-    --h3-color: rgb(var(--callout-color));
-    --h4-color: rgb(var(--callout-color));
-    --h5-color: rgb(var(--callout-color));
-    --h6-color: rgb(var(--callout-color));
+    --h1-color: var(--callout-color);
+    --h2-color: var(--callout-color);
+    --h3-color: var(--callout-color);
+    --h4-color: var(--callout-color);
+    --h5-color: var(--callout-color);
+    --h6-color: var(--callout-color);
   }
 }


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
